### PR TITLE
frp error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,49 @@ Returns a new event which behaves identically to the given event, but which also
 has a `release` function. When called, this breaks the link between the original
 event and the returned event.
 
+### Error Handling
+
+#### `frp.error(message)`
+
+There are times when an Event will not return a value but rather an error message should
+be sent.
+
+For this reason `frp.error` was created. `frp.error` will not return a standard
+Javascript `Error` but simple an `Object` with an error message. This allows for an `frp.event`
+to fire regular Javascript errors also.
+
+In the same way you can `watch` and `bind` an event you can watch for error messages using
+the `catch` function or method:
+
+<h4><pre>
+catch(event, fn)
+event.catch(fn)
+</pre></h4>
+
+Example:
+```javascript
+var pipe = frp.event.pipe();
+
+pipe
+.watch(function(value) {
+    console.log(value); // will log 'Will go into watch'
+})
+.catch(function(error) {
+    console.log(error.message); // will log ''
+});
+
+pipe.fire('Will go into watch');
+pipe.fire(frp.error('Will go into catch'));
+```
+
+In the same way you can `unwatch` a `watch` you can `uncatch` a `catch`.
+
+<h4><pre>
+uncatch(event, fn)
+event.uncatch(fn)
+</pre></h4>
+
+
 
 ## Signal
 

--- a/src/error.js
+++ b/src/error.js
@@ -1,0 +1,8 @@
+var error = module.exports = function(message) {
+
+	return {
+
+		message: message,
+		isError: true
+	};
+};

--- a/src/error.js
+++ b/src/error.js
@@ -1,8 +1,17 @@
+var _ = require( 'lodash' );
+
+var secret = 'frp.error';
+
 var error = module.exports = function(message) {
 
 	return {
 
 		message: message,
-		isError: true
+		isError: secret
 	};
+};
+
+error.isError = function( value ) {
+
+	return _.isObject( value ) && value.isError == secret;
 };

--- a/src/event.js
+++ b/src/event.js
@@ -1,16 +1,19 @@
 var _ = require('lodash');
 
-var Event = module.exports = function(watch, unwatch) {
+var Event = module.exports = function(watch, unwatch, catchFunc, uncatch) {
   return _.assign({
     watch: watch,
     bind: watch,
+    catch: catchFunc,
     unwatch: unwatch,
-    unbind: unwatch
+    unbind: unwatch,
+    uncatch: uncatch
   }, Event.methods);
 };
 
 var Pipe = Event.pipe = function() {
-  var watchers = [];
+  var watchers = [],
+      catchers = [];
 
   var unwatch = function(cb) {
     _.pull(watchers, cb);
@@ -21,16 +24,33 @@ var Pipe = Event.pipe = function() {
     return _.partial(unwatch, cb);
   };
 
-  var event = Event(watch, unwatch);
+  var uncatch = function(cb) {
+    _.pull(catchers, cb);
+  };
+
+  var catchFunc = function(cb) {
+    catchers.push(cb);
+    return _.partial(uncatch, cb);
+  };
+
+  var event = Event(watch, unwatch, catchFunc, uncatch);
 
   return _.assign({}, event, {
     fire: function(value) {
-      watchers.forEach(function(watcher) {
-        watcher(value);
-      });
+      if(_.isObject(value) && value.isError) {
+        catchers.forEach(function(catcher) {
+          catcher(value);
+        });
+      } else {
+        watchers.forEach(function(watcher) {
+          watcher(value);
+        });
+      }
     },
     watch: watch,
     unwatch: unwatch,
+    catch: catchFunc,
+    uncatch: uncatch,
     bind: watch,
     unbind: unwatch,
     event: event

--- a/src/event.js
+++ b/src/event.js
@@ -1,4 +1,5 @@
 var _ = require('lodash');
+var error = require( './error' );
 
 var Event = module.exports = function(watch, unwatch, catchFunc, uncatch) {
   return _.assign({
@@ -37,7 +38,7 @@ var Pipe = Event.pipe = function() {
 
   return _.assign({}, event, {
     fire: function(value) {
-      if(_.isObject(value) && value.isError) {
+      if( error.isError(value) ) {
         catchers.forEach(function(catcher) {
           catcher(value);
         });

--- a/src/index.js
+++ b/src/index.js
@@ -2,3 +2,4 @@ exports.event = require('./event');
 exports.signal = require('./signal');
 exports.cell = require('./cell');
 exports.pipe = require('./pipe');
+exports.error = require('./error');

--- a/src/signal.js
+++ b/src/signal.js
@@ -21,7 +21,13 @@ Signal.event = function() {
 
   var value = initial;
 
-  event.watch(function(newValue) { value = newValue; empty = false; });
+  event.watch(function(newValue) { 
+
+    if(!_.isObject(newValue) || !newValue.isError) {
+      value = newValue; 
+      empty = false; 
+    }
+  });
 
   var r = _.assign({
     get: function() { return value; },

--- a/src/signal.js
+++ b/src/signal.js
@@ -1,5 +1,6 @@
 var _ = require('lodash');
 var Event = require('./event');
+var error = require( './error' );
 
 var Signal = module.exports = {};
 
@@ -23,7 +24,7 @@ Signal.event = function() {
 
   event.watch(function(newValue) { 
 
-    if(!_.isObject(newValue) || !newValue.isError) {
+    if(!error.isError(newValue)) {
       value = newValue; 
       empty = false; 
     }

--- a/test/event.js
+++ b/test/event.js
@@ -1,4 +1,5 @@
 var assert = require('assert');
+var frp = require('./..');
 var Event = require('../src/event');
 var Pipe = require('../src/pipe');
 
@@ -34,6 +35,21 @@ suite('event', function() {
 
     assert.deepEqual(a, [1, 2, 5, 6]);
 
+  });
+
+  test('catch', function() {
+    var ctrl = Pipe();
+    var fire = ctrl.fire;
+
+    ctrl.event.watch(function(value) {
+      assert(!value.isError, 'An error was sent to watch');
+    });
+
+    ctrl.event.catch(function(error) {
+      assert(error.isError, 'Didn\'t receive an error');
+    });
+
+    fire(frp.error('should not be received by watch'));    
   });
 
   test('concise unwatch', function() {

--- a/test/signal.js
+++ b/test/signal.js
@@ -1,4 +1,5 @@
 var assert = require('assert');
+var frp = require('./..');
 var Event = require('../src/event');
 var Signal = require('../src/signal');
 var Pipe = require('../src/pipe');
@@ -63,6 +64,14 @@ suite('signal', function() {
     sig.unwatch(cb);
     cell.set(44);
     assert.deepEqual(values, [43]);
+  });
+
+  test('catch', function() {
+    var cell = Signal.cell(42);
+
+    cell.set(frp.error('Uh uh dont set me'));
+
+    assert(cell.value,42,'Received error');
   });
 
   test('concise unwatch', function() {


### PR DESCRIPTION
I was creating a module called `frp-promise`. https://github.com/MikkoH/frp-promise

I realized that there really needs to be handling for errors in the core `frp` module.

I implemented it in a way where there's a new data type `frp.error`. This allows for `events` and `signals` to still be able to fire off regular Javascript errors while still maintaining the ability to throw frp errors.

For instance from a `frp.event` which fires `promise` callbacks you could do something like:

``` javascript
var frpPromise = require( 'frp-promise' );

frpPromise( somePromise )
.watch( function( value ) {
  handleSucces( value );
})
.error( function( error ) {
  handleError( error );
});
```

Something to consider is error handling in `map` etc. Should they be auto caught? I'm not sure. I'd say no but it's a thought.
